### PR TITLE
Fix GitHub display name typo

### DIFF
--- a/modules/github.py
+++ b/modules/github.py
@@ -20,7 +20,7 @@ def github_find(user, verbose):
     # Extract user information
     user_info = {}
     user_info['username'] = user
-    user_info['display_name'] = user_profile.find('span', class_='p-name').text.strip() if user_profile.find('span', class_='p-name') else 'No diplay name'
+    user_info['display_name'] = user_profile.find('span', class_='p-name').text.strip() if user_profile.find('span', class_='p-name') else 'No display name'
     user_info['bio'] = user_profile.find('div', class_='p-note').text.strip() if user_profile.find('div', class_='p-note') else 'No bio'
     user_info['location'] = user_profile.find('span', class_='p-label').text.strip() if user_profile.find('span', class_='p-label') else 'No location'
 


### PR DESCRIPTION
## Summary
- fix typo in GitHub module
- ensure newline at end of file

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840b5dbcbe0832bae39f638b3d54878