### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -8,6 +8,9 @@ on:
   release:
     types: [ published ]
 
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: "3.11"
   REGISTRY: ghcr.io


### PR DESCRIPTION
Potential fix for [https://github.com/Huleinpylo/GitOSINT-mcp/security/code-scanning/22](https://github.com/Huleinpylo/GitOSINT-mcp/security/code-scanning/22)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the provided workflow, it appears to primarily involve testing and setup tasks, which likely only require `contents: read` permissions. 

The `permissions` block can be added at the root level of the workflow to apply to all jobs or at the job level for more granular control. In this case, adding it at the root level is sufficient and simplifies the configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
