### PR TITLE
Potential fix for code scanning alert no. 16: Incomplete URL substring sanitization

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -471,7 +471,9 @@ def assert_valid_url(url):
 def assert_valid_github_url(url):
     """Assert that a string is a valid GitHub URL"""
     assert_valid_url(url)
-    assert "github.com" in url
+    from urllib.parse import urlparse
+    hostname = urlparse(url).hostname
+    assert hostname and (hostname == "github.com" or hostname.endswith(".github.com"))
 
 
 def assert_valid_gitlab_url(url):


### PR DESCRIPTION
Potential fix for [https://github.com/Huleinpylo/GitOSINT-mcp/security/code-scanning/16](https://github.com/Huleinpylo/GitOSINT-mcp/security/code-scanning/16)

To fix the issue, the function `assert_valid_github_url` should parse the URL using `urlparse` and validate the hostname explicitly. This ensures that the check is performed on the correct part of the URL and avoids the risks associated with substring checks. Specifically, the hostname should be checked to ensure it matches `github.com` or ends with `.github.com` (to allow for subdomains if needed). This approach aligns with the recommendation provided in the background.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
